### PR TITLE
ci: add caching for python dependencies

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v2


### PR DESCRIPTION
Based on this: https://github.com/darbiadev/.github/blob/main/.github/workflows/python-lint.yaml#L14-L18

Might need to bump the action version too if this says the keys don't exist.